### PR TITLE
Only return `nonce` from given payload

### DIFF
--- a/pydiscourse/sso.py
+++ b/pydiscourse/sso.py
@@ -27,9 +27,10 @@ import hmac
 import hashlib
 
 try:  # py3
-    from urllib.parse import unquote, urlencode
+    from urllib.parse import unquote, urlencode, parse_qs
 except ImportError:
     from urllib import unquote, urlencode
+    from urlparse import parse_qs
 
 
 from pydiscourse.exceptions import DiscourseError
@@ -63,9 +64,9 @@ def sso_validate(payload, signature, secret):
     if this_signature != signature:
         raise DiscourseError('Payload does not match signature.')
 
-    nonce = decoded.split('=')[1]
-
-    return nonce
+    # Discourse returns querystring encoded value. We only need `nonce`
+    qs = parse_qs(decoded)
+    return qs['nonce'][0]
 
 
 def sso_payload(secret, **kwargs):


### PR DESCRIPTION
When trying to use the library I encountered the following error message upon redirecting to Discourse: `Account login timed out, please try logging in again.`. 
Looking at the payload received from Discourse, it was something like `nonce=XXXX&return_sso_url=http%3A%2F%2Fcommunity.mywebsite.com%2Fsession%2Fsso_login`

I can't find good documentation for this but I think their intention is to return a querystring with multiple variables, one of which is the `nonce` the other is the redirect URL. Instead of splitting on `=` I used `parse_qs` to parse the payload. That solved the problem for me and should generally work better even when this problem does not exist.