### PR TITLE
Added badges endpoint to pydiscourse

### DIFF
--- a/pydiscourse/client.py
+++ b/pydiscourse/client.py
@@ -566,6 +566,17 @@ class DiscourseClient(object):
         """
         return self._post('/user_badges', username=username, badge_id=badge_id, **kwargs)
 
+    def user_badges(self, username, **kwargs):
+        """
+
+        Args:
+            username:
+
+        Returns:
+
+        """
+        return self._get('/user-badges/{}.json'.format(username))
+
 
     def create_category(self, name, color, text_color='FFFFFF',
                         permissions=None, parent=None, **kwargs):

--- a/pydiscourse/client.py
+++ b/pydiscourse/client.py
@@ -541,6 +541,32 @@ class DiscourseClient(object):
         kwargs['term'] = term
         return self._get('/search.json', **kwargs)
 
+
+    def badges(self, **kwargs):
+        """
+
+        Args:
+            **kwargs:
+
+        Returns:
+
+        """
+        return self._get('/admin/badges.json', **kwargs)
+
+    def grant_badge_to(self, username, badge_id, **kwargs):
+        """
+
+        Args:
+            username:
+            badge_id:
+            **kwargs:
+
+        Returns:
+
+        """
+        return self._post('/user_badges', username=username, badge_id=badge_id, **kwargs)
+
+
     def create_category(self, name, color, text_color='FFFFFF',
                         permissions=None, parent=None, **kwargs):
         """

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -175,3 +175,13 @@ class MiscellaneousTests(ClientBaseTestCase):
         prepare_response(request)
         self.client.users()
         self.assertRequestCalled(request, 'GET', '/admin/users/list/active.json')
+
+    def test_badges(self, request):
+        prepare_response(request)
+        self.client.badges()
+        self.assertRequestCalled(request, 'GET', '/admin/badges.json')
+
+    def test_grant_badge_to(self, request):
+        prepare_response(request)
+        self.client.grant_badge_to('username', 1)
+        self.assertRequestCalled(request, 'POST', '/user_badges', username='username', badge_id=1)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -120,6 +120,11 @@ class TestUser(ClientBaseTestCase):
         self.client.unsuspend(123)
         self.assertRequestCalled(request, 'PUT', '/admin/users/123/unsuspend')
 
+    def test_user_bagdes(self, request):
+        prepare_response(request)
+        self.client.user_badges('username')
+        self.assertRequestCalled(request, 'GET', '/user-badges/{}.json'.format('username'))
+
 
 @mock.patch('requests.request')
 class TestTopics(ClientBaseTestCase):


### PR DESCRIPTION
Hi!

I'm using pydiscourse to consume Discourse API, but I saw that Badges endpoint isn't in pydiscourse. Then I made it! :)