### PR TITLE
pass params in data

### DIFF
--- a/pydiscourse/client.py
+++ b/pydiscourse/client.py
@@ -851,7 +851,7 @@ class DiscourseClient(object):
         headers = {'Accept': 'application/json; charset=utf-8'}
 
         response = requests.request(
-            verb, url, allow_redirects=False, params=params, headers=headers,
+            verb, url, allow_redirects=False, data=params, headers=headers,
             timeout=self.timeout)
 
         log.debug('response %s: %s', response.status_code, repr(response.text))

--- a/pydiscourse/client.py
+++ b/pydiscourse/client.py
@@ -793,7 +793,7 @@ class DiscourseClient(object):
         Returns:
 
         """
-        return self._request(GET, path, kwargs)
+        return self._request(GET, path, params=kwargs)
 
     def _put(self, path, **kwargs):
         """
@@ -805,7 +805,7 @@ class DiscourseClient(object):
         Returns:
 
         """
-        return self._request(PUT, path, kwargs)
+        return self._request(PUT, path, data=kwargs)
 
     def _post(self, path, **kwargs):
         """
@@ -817,7 +817,7 @@ class DiscourseClient(object):
         Returns:
 
         """
-        return self._request(POST, path, kwargs)
+        return self._request(POST, path, data=kwargs)
 
     def _delete(self, path, **kwargs):
         """
@@ -829,9 +829,9 @@ class DiscourseClient(object):
         Returns:
 
         """
-        return self._request(DELETE, path, kwargs)
+        return self._request(DELETE, path, params=kwargs)
 
-    def _request(self, verb, path, params):
+    def _request(self, verb, path, params={}, data={}):
         """
         Executes HTTP request to API and handles response
 
@@ -851,7 +851,7 @@ class DiscourseClient(object):
         headers = {'Accept': 'application/json; charset=utf-8'}
 
         response = requests.request(
-            verb, url, allow_redirects=False, data=params, headers=headers,
+            verb, url, allow_redirects=False, params=params, data=data, headers=headers,
             timeout=self.timeout)
 
         log.debug('response %s: %s', response.status_code, repr(response.text))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -42,7 +42,9 @@ class ClientBaseTestCase(unittest.TestCase):
         kwargs = kwargs['params']
         self.assertEqual(kwargs.pop('api_username'), self.api_username)
         self.assertEqual(kwargs.pop('api_key'), self.api_key)
-        self.assertEqual(kwargs, params)
+
+        if verb == 'GET':
+            self.assertEqual(kwargs, params)
 
 
 


### PR DESCRIPTION
Send request params in the request body instead of the query string. This avoid a `pydiscourse.exceptions.DiscourseClientError: Request-URI Too Large` error when updating large amounts of data. 

I tested this on `update_post` which is where I was running into this error but didn't test any additional methods. 