### PR TITLE
Authenticate via headers

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,4 +9,4 @@ Scott Nixon
 Jason Dorweiler
 Pierre-Alain Dupont
 Karl Goetz
-
+Alex Kerney

--- a/pydiscourse/client.py
+++ b/pydiscourse/client.py
@@ -1350,12 +1350,13 @@ class DiscourseClient(object):
             dictionary of response body data or None
 
         """
-        params["api_key"] = self.api_key
-        if "api_username" not in params:
-            params["api_username"] = self.api_username
         url = self.host + path
 
-        headers = {"Accept": "application/json; charset=utf-8"}
+        headers = {
+            "Accept": "application/json; charset=utf-8",
+            "Api-Key": self.api_key,
+            "Api-Username": self.api_username,
+        }
 
         # How many times should we retry if rate limited
         retry_count = 4

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -49,12 +49,12 @@ class ClientBaseTestCase(unittest.TestCase):
         self.assertEqual(args[0], verb)
         self.assertEqual(args[1], self.host + url)
 
-        kwargs = kwargs["params"]
-        self.assertEqual(kwargs.pop("api_username"), self.api_username)
-        self.assertEqual(kwargs.pop("api_key"), self.api_key)
+        headers = kwargs["headers"]
+        self.assertEqual(headers.pop("Api-Username"), self.api_username)
+        self.assertEqual(headers.pop("Api-Key"), self.api_key)
 
         if verb == "GET":
-            self.assertEqual(kwargs, params)
+            self.assertEqual(kwargs["params"], params)
 
 
 class TestClientRequests(ClientBaseTestCase):


### PR DESCRIPTION
### Summary of changes

The Discourse API is changing to only accept [authentication via headers](https://meta.discourse.org/t/discourse-api-documentation/22706).

There currently isn't a defined [timeline](https://meta.discourse.org/t/discourse-api-documentation/22706/265) on the API change.

This PR changes the `DiscourseClient._request()` method to pass the API key and username via headers rather than via params.

Closes bennylope/pydiscourse#27

## Checklist

- [x] Changes represent a *discrete update*
- [x] Commit messages are meaningful and descriptive
- [x] Changeset does not include any extraneous changes unrelated to the discrete change
