### PR TITLE
Fix call to get group info by name

### DIFF
--- a/pydiscourse/client.py
+++ b/pydiscourse/client.py
@@ -949,7 +949,7 @@ class DiscourseClient(object):
         """
         Get all infos of a group by group name
         """
-        return self._get("/groups/{0}/members.json".format(group_name))
+        return self._get("/groups/{0}.json".format(group_name))
 
     def create_group(
         self,


### PR DESCRIPTION
### Summary of changes
Changed the group() function in client.py to use the correct API endpoint to get group information. It was previously getting group members instead.

## Checklist

- [x] Changes represent a *discrete update*
- [x] Commit messages are meaningful and descriptive
- [x] Changeset does not include any extraneous changes unrelated to the discrete change
