### PR TITLE
Fix 413 response from Discourse due to empty dict passed as json

### DIFF
--- a/pydiscourse/client.py
+++ b/pydiscourse/client.py
@@ -1357,10 +1357,6 @@ class DiscourseClient(object):
             dictionary of response body data or None
 
         """
-        params = params or {}
-        files = files or {}
-        data = data or {}
-        json = json or {}
         override_request_kwargs = override_request_kwargs or {}
 
         url = self.host + path


### PR DESCRIPTION
### Summary of changes

Prevents Discourse from returning `413 Payload too large` errors due to an empty JSON object being submitted with requests that don't otherwise specify the `json=` argument.

Requests correctly handles `None` being passed to keyword arguments, but does not ignore empty dictionaries.

Closes #35 


## Checklist

- [x] Changes represent a *discrete update*
- [x] Commit messages are meaningful and descriptive
- [x] Changeset does not include any extraneous changes unrelated to the discrete change
