### PR TITLE
Add workflow to publish package to PyPI on tag/release (fixes #43)

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,33 @@
+name: Publish package to PyPI
+
+on: 
+  push:
+    branches: [master]
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+
+    - name: Build and publish distribution
+      if: (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')) || github.event_name == 'release'
+      env: 
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*


### PR DESCRIPTION
### Summary of changes
GitHub workflow to build and publish package to PyPI when a tagged commit is pushed to the master branch _or_ when a manual release is drafted.

@bennylope you (I assume you, at least) will need to generate two encrypted secrets, namely `PYPI_USERNAME` and `PYPI_PASSWORD`, for this to work (see https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets).

## Checklist

- [X] Changes represent a *discrete update*
- [X] Commit messages are meaningful and descriptive
- [X] Changeset does not include any extraneous changes unrelated to the discrete change
