### PR TITLE
fix(errors): handle data-explorer responses

### DIFF
--- a/pydiscourse/client.py
+++ b/pydiscourse/client.py
@@ -1547,7 +1547,10 @@ class DiscourseClient(object):
         except ValueError:
             raise DiscourseError("failed to decode response", response=response)
 
-        if "errors" in decoded:
+        # Checking "errors" length because
+        # data-explorer (e.g. POST /admin/plugins/explorer/queries/{}/run)
+        # sends an empty errors array
+        if "errors" in decoded and len(decoded["errors"]) > 0:
             message = decoded.get("message")
             if not message:
                 message = u",".join(decoded["errors"])


### PR DESCRIPTION
### Summary of changes

Following this review : https://github.com/bennylope/pydiscourse/pull/49#discussion_r568536975, I found why we needed to check for errors length.

When making calls with Data Explorer, the request looks like
```
POST /admin/plugins/explorer/queries/1/run
200 '{"success":true,"errors":[],"duration":4.2,"result_count":0,"params":{},"columns" ["id","username"],"default_limit":1000,"relations":{},"colrender":{},"rows":[]}'
```

Without the changes included in this PR, a successful request throws an error (`DiscourseError No exception message supplied`).


## Checklist

- [x] Changes represent a *discrete update*
- [x] Commit messages are meaningful and descriptive
- [x] Changeset does not include any extraneous changes unrelated to the discrete change

Thanks !