### PR TITLE
Use new API for add_group_owner

### DIFF
--- a/src/pydiscourse/client.py
+++ b/src/pydiscourse/client.py
@@ -1119,7 +1119,7 @@ class DiscourseClient(object):
 
         """
         return self._put(
-            "/admin/groups/{0}/owners.json".format(groupid), usernames=username
+            "/admin/groups/{0}/owners.json".format(groupid), **{"group[usernames]": username}
         )
 
     def delete_group_owner(self, groupid, userid):


### PR DESCRIPTION
Closes #61

### Summary of changes

Use the new API for adding group owners.

## Checklist

- [x] Changes represent a *discrete update*
- [x] Commit messages are meaningful and descriptive
- [x] Changeset does not include any extraneous changes unrelated to the discrete change
