### PR TITLE
Add group owners

### DIFF
--- a/src/pydiscourse/client.py
+++ b/src/pydiscourse/client.py
@@ -1119,7 +1119,7 @@ class DiscourseClient(object):
 
         """
         return self._put(
-            "/admin/groups/{0}/owners.json".format(groupid), usernames=username
+            "/admin/groups/{0}/owners.json".format(groupid), **{"group[usernames]": username}
         )
 
     def delete_group_owner(self, groupid, userid):

--- a/src/pydiscourse/client.py
+++ b/src/pydiscourse/client.py
@@ -1122,6 +1122,23 @@ class DiscourseClient(object):
             "/admin/groups/{0}/owners.json".format(groupid), **{"group[usernames]": username}
         )
 
+    def add_group_owners(self, groupid, usernames):
+        """
+        Add a list of owners to a group by usernames
+
+        Args:
+            groupid: the ID of the group
+            username: the list of new owner usernames
+
+        Returns:
+            JSON API response
+
+        """
+        usernames = ",".join(usernames)
+        return self._put(
+            "/admin/groups/{0}/owners.json".format(groupid), **{"group[usernames]": usernames}
+        )
+
     def delete_group_owner(self, groupid, userid):
         """
         Deletes an owner from a group by user ID


### PR DESCRIPTION
Closes #64

### Summary of changes

Add an `add_group_owners` method to add multiple owners by list.

This is based on #63, please merge that one before this one.

## Checklist

- [x] Changes represent a *discrete update*
- [x] Commit messages are meaningful and descriptive
- [x] Changeset does not include any extraneous changes unrelated to the discrete change
