### PR TITLE
Rate limit improvements

### DIFF
--- a/src/pydiscourse/client.py
+++ b/src/pydiscourse/client.py
@@ -1561,7 +1561,8 @@ class DiscourseClient(object):
                 if 400 <= response.status_code < 500:
                     if 429 == response.status_code:
                         # This codepath relies on wait_seconds from Discourse v2.0.0.beta3 / v1.9.3 or higher.
-                        if "application/json" in response.headers.get("Content-Type"):
+                        content_type = response.headers.get("Content-Type")
+                        if content_type is not None and "application/json" in content_type:
                             ret = response.json()
                             wait_delay = (
                                 retry_backoff + ret["extras"]["wait_seconds"]

--- a/src/pydiscourse/client.py
+++ b/src/pydiscourse/client.py
@@ -1572,14 +1572,17 @@ class DiscourseClient(object):
                             ret = response.content
                             wait_delay = retry_backoff + 10
 
+                        limit_name = response.headers.get(
+                                "Discourse-Rate-Limit-Error-Code", "<unknown>")
+
+                        log.info(
+                                "We have been rate limited (limit: {2}) and will wait {0} seconds ({1} retries left)".format(
+                                wait_delay, retry_count, limit_name
+                            )
+                        )
                         if retry_count > 1:
                             time.sleep(wait_delay)
                         retry_count -= 1
-                        log.info(
-                            "We have been rate limited and waited {0} seconds ({1} retries left)".format(
-                                wait_delay, retry_count
-                            )
-                        )
                         log.debug("API returned {0}".format(ret))
                         continue
                     else:


### PR DESCRIPTION
### Summary of changes

Two changes here, happy to split if you would prefer.

- First, with my Discourse instance (v2.8.13 on nginx, in case it makes a difference), I encountered rate-limited responses that did not have a `Content-Type` header. The first commit makes it so that the code takes these in stride.
- The second commit includes information from the `Discourse-Rate-Limit-Error-Code`, which makes it easier to debug which limit is encountered. Also, logging happens before waiting, to provide feedback on what is happening.

## Checklist

- [x] Changes represent a *discrete update* (-ish)
- [x] Commit messages are meaningful and descriptive
- [x] Changeset does not include any extraneous changes unrelated to the discrete change
