### PR TITLE
Add endpoint to fetch latest posts across topics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,9 @@ coverage.xml
 
 # Sphinx documentation
 docs/_build/
+
+# Pyenv
+.python-version
+
+# PyCharm
+.idea

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -43,7 +43,7 @@ Or it's slightly faster cousin `detox
 
 Alternatively, you can run the self test with the following commands::
 
-    pip install -r requirements.dev.txt
+    pip install -r requirements.txt
     pip install -e .
     python setup.py test
 

--- a/src/pydiscourse/client.py
+++ b/src/pydiscourse/client.py
@@ -649,6 +649,21 @@ class DiscourseClient(object):
             kwargs["post_ids[]"] = post_ids
         return self._get("/t/{0}/posts.json".format(topic_id), **kwargs)
 
+    def latest_posts(self, before=None, **kwargs):
+        """
+        List latest posts across topics
+
+        Args:
+            before: Load posts with an id lower than this value. Useful for pagination.
+            **kwargs:
+
+        Returns:
+
+        """
+        if before:
+            kwargs["before"] = before
+        return self._get("/posts.json", **kwargs)
+
     def topic_timings(self, topic_id, time, timings={}, **kwargs):
         """
         Set time spent reading a post

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -182,6 +182,11 @@ class TestTopics(ClientBaseTestCase):
 @mock.patch("pydiscourse.client.requests.request")
 class MiscellaneousTests(ClientBaseTestCase):
 
+    def test_latest_posts(self, request):
+        prepare_response(request)
+        r = self.client.latest_posts(before=54321)
+        self.assertRequestCalled(request, "GET", "/posts.json", before=54321)
+
     def test_search(self, request):
         prepare_response(request)
         self.client.search("needle")


### PR DESCRIPTION
Added endpoint for looking up latest posts across topics, see Discourse api documentation here:

https://docs.discourse.org/#tag/Posts/operation/listPosts

Also corrected incorrect requirements file name in documentation and added .gitignore sections for PyCharm and `pyenv`.

## Checklist

- [X] Changes represent a *discrete update*
- [X] Commit messages are meaningful and descriptive
- [X] Changeset does not include any extraneous changes unrelated to the discrete change
