### PR TITLE
Fix python version display in github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on: [ push, pull_request ]
 jobs:
   test:
 
-    name: Test on Python ${{ matrix.py_version }}
+    name: Test on Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
test.yml uses the wrong python version variable which is causing it to not display the title correctly in the github actions interface, see github documentation here:

https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#using-the-python-starter-workflow

### Summary of changes


## Checklist

- [X] Changes represent a *discrete update*
- [X] Commit messages are meaningful and descriptive
- [X] Changeset does not include any extraneous changes unrelated to the discrete change
