### PR TITLE
Add client endpoint for updating category

### DIFF
--- a/src/pydiscourse/client.py
+++ b/src/pydiscourse/client.py
@@ -937,6 +937,18 @@ class DiscourseClient(object):
 
         return self._get(u"/c/{0}/show.json".format(category_id), **kwargs)
 
+    def update_category(self, category_id, **kwargs):
+        """
+
+        Args:
+            category_id:
+            **kwargs:
+
+        Returns:
+
+        """
+        return self._put("/categories/{0}".format(category_id), json=True, **kwargs)
+
     def delete_category(self, category_id, **kwargs):
         """
         Remove category

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -198,6 +198,11 @@ class MiscellaneousTests(ClientBaseTestCase):
         self.assertRequestCalled(request, "GET", "/categories.json")
         self.assertEqual(r, request().json()["category_list"]["categories"])
 
+    def test_update_category(self, request):
+        prepare_response(request)
+        self.client.update_category(123, a="a", b="b")
+        self.assertRequestCalled(request, "PUT", "/categories/123", a="a", b="b")
+
     def test_users(self, request):
         prepare_response(request)
         self.client.users()


### PR DESCRIPTION
### Summary of changes
Add endpoint to update category settings via the api. I have tested that the new method adds a new tag group to an existing category against my Discourse instance, see the example code below:

```
from munch import DefaultMunch

...

category = DefaultMunch.fromDict(discourse_client.category(category_id)["category"])

        if STAFF_ONLY_TAG_GROUP_NAME not in category.allowed_tag_groups:
            category.allowed_tag_groups.append(STAFF_ONLY_TAG_GROUP_NAME)
            discourse_client.update_category(
                category_id, allowed_tag_groups=category.allowed_tag_groups
            )
```
## Checklist

- [X] Changes represent a *discrete update*
- [X] Commit messages are meaningful and descriptive
- [X] Changeset does not include any extraneous changes unrelated to the discrete change
